### PR TITLE
Enable generation of testnet xPub

### DIFF
--- a/include/mpc_crypto.h
+++ b/include/mpc_crypto.h
@@ -160,7 +160,7 @@ MPCCRYPTO_API int MPCCrypto_restoreEddsaKey(const uint8_t* prv_backup_key, int p
 MPCCRYPTO_API int MPCCrypto_initDeriveBIP32(int peer, MPCCryptoShare* share, int hardened, unsigned index, MPCCryptoContext** context);
 MPCCRYPTO_API int MPCCrypto_getResultDeriveBIP32(MPCCryptoContext* context, MPCCryptoShare** new_share);
 MPCCRYPTO_API int MPCCrypto_getBIP32Info(MPCCryptoShare* share, bip32_info_t* bip32_info);
-MPCCRYPTO_API int MPCCrypto_serializePubBIP32(MPCCryptoShare* share, char* out, int* out_size);
+MPCCRYPTO_API int MPCCrypto_serializePubBIP32(MPCCryptoShare* share, char* out, int* out_size, bool main = true);
 
 
 #ifdef __cplusplus

--- a/src/mpc_crypto_ecdsa_bip.cpp
+++ b/src/mpc_crypto_ecdsa_bip.cpp
@@ -932,7 +932,7 @@ MPCCRYPTO_API int MPCCrypto_getBIP32Info(MPCCryptoShare* share_ptr, bip32_info_t
   return rv;
 }
 
-MPCCRYPTO_API int MPCCrypto_serializePubBIP32(MPCCryptoShare* share_ptr, char* out, int* out_size)
+MPCCRYPTO_API int MPCCrypto_serializePubBIP32(MPCCryptoShare* share_ptr, char* out, int* out_size, bool main)
 {
   error_t rv = 0;
   if (!share_ptr) return rv = ub::error(E_BADARG);
@@ -953,7 +953,7 @@ MPCCRYPTO_API int MPCCrypto_serializePubBIP32(MPCCryptoShare* share_ptr, char* o
   bip_node.set_parent_fingerprint(bip_key_info.parent_fingerprint);
   bip_node.set_level(bip_key_info.level);
 
-  std::string s = bip_node.serialize_pub(Q.to_compressed_oct());
+  std::string s = bip_node.serialize_pub(Q.to_compressed_oct(), main);
   int len = (int)s.length()+1;
   int buf_size = *out_size;
   *out_size = len;

--- a/src/mpc_crypto_jni.cpp
+++ b/src/mpc_crypto_jni.cpp
@@ -512,13 +512,13 @@ JNIEXPORT jint JNICALL Java_com_unboundTech_mpc_Native_getBIP32Info(JNIEnv *env,
   return 0;
 }
 
-JNIEXPORT jint JNICALL Java_com_unboundTech_mpc_Native_serializePubBIP32(JNIEnv *env, jclass, jlong share_handle, jcharArray j_out, jobject j_out_size)
+JNIEXPORT jint JNICALL Java_com_unboundTech_mpc_Native_serializePubBIP32(JNIEnv *env, jclass, jlong share_handle, jcharArray j_out, jobject j_out_size, jboolean main)
 {
   error_t rv = 0;
   MPCCryptoShare* share = (MPCCryptoShare*)(uintptr_t)share_handle;
 
   int str_size = 0;
-  rv = MPCCrypto_serializePubBIP32(share, nullptr, &str_size);
+  rv = MPCCrypto_serializePubBIP32(share, nullptr, &str_size, main);
   int out_size = str_size-1;
 
   if (j_out_size) set_int_ref(env, j_out_size, out_size);


### PR DESCRIPTION
Hi,

i know this project is not being maintained anymore, but I decided to open this anyway, maybe it will be usefull for someone in the future.

I noticed that `MPCCrypto_serializePubBIP32` has all the necessary logic to create test net xPub keys. The regarding functions even have a parameter to control that. But the parameter has a default value and is never changed by calling methods. The exposed functions by the library (inside `mpc_crypto.h`) do not offer a way to pass that information. I just added the parameter `bool main` and passed it down to `serialize_pub` which accepted this parameter anyway.

(bool main representing wether the xPub is generated for mainnet or not)